### PR TITLE
Clarify when/where to install package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ```bash
 npm i angular-universal-express-firebase
 ```
+NB: Run this command _afer_ initialzing functions and from within the `functions` folder
 
 ## Basic Usage
 ```js


### PR DESCRIPTION
Users need to know exactly when and where to install the npm package. Most projects just have one `package.json` folder, but when initializing functions, we have a sub-directory with its own `package.json` file. Function-specific packages need to be installed there. Fixes #1 